### PR TITLE
ubuntuでlibjpegのインストールを追加

### DIFF
--- a/.github/workflows/build_as_artifacts.yml
+++ b/.github/workflows/build_as_artifacts.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
           - macos-latest
           - windows-latest
         ocaml-compiler:
           - 5
-        exclude:
-          - os: macos-latest
+        include:
+          # https://gitlab.com/camlspotter/camlimages/-/issues/6
+          - os: ubuntu-latest
             ocaml-compiler: 4
 
     runs-on: ${{ matrix.os }}
@@ -38,6 +38,13 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      # Ubuntuの場合のみ実行
+      - name: Install libjpeg on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjpeg-dev
 
       - run: opam install . --deps-only --with-test
 


### PR DESCRIPTION
camlimagesのjpeg処理はローカルにあるlibjpegをスタティックリンクすることによって実現されているためパッケージインストール処理を追加します。
なお https://gitlab.com/camlspotter/camlimages/-/issues/6 によりOCaml5系ではビルドできないため、Ubuntu版は4系を指定しています。
windows版はこれでもまだ動かない模様です